### PR TITLE
Break requirements.txt into environment specific modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ git clone https://github.com/psf/python-in-edu.git
 cd python-in-edu
 python3 -m venv .venv
 source .venv/bin/activate
-pip install -r requirements.txt
+pip install -r requirements/dev.txt
 ```
 
 You can then change directories into the python-in-edu folder and build the database:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,21 +1,4 @@
-asgiref==3.3.1
-confusable-homoglyphs==3.2.0
-dj-database-url==0.5.0
-Django==3.1.6
-django-djconfig==0.10.0
-django-haystack==3.0
-django-heroku==0.3.1
-django-infinite-scroll-pagination==1.1.0
-django-multiselectfield==0.1.12
-django-registration==3.1.1
-django-spirit==0.12.2
-gunicorn==20.0.4
-mistune==0.8.4
-olefile==0.46
-Pillow==8.0.1
-psycopg2==2.8.6
-python-dotenv==0.15.0
-pytz==2021.1
-sqlparse==0.4.1
-whitenoise==5.2.0
-Whoosh==2.7.4
+# This file is required by Heroku and should not be installed locally
+#
+# See our README for getting started locally.
+-r requirements/prod.txt

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,0 +1,10 @@
+Django==3.1.6
+django-djconfig==0.10.0
+django-haystack==3.0
+django-multiselectfield==0.1.12
+django-registration==3.1.1
+django-spirit==0.12.2
+dj-database-url==0.5.0
+gunicorn==20.0.4
+python-dotenv==0.15.0
+whitenoise==5.2.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,0 +1,3 @@
+-r base.txt
+
+# Add dependencies specific to development below

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1,0 +1,3 @@
+-r base.txt
+
+psycopg2==2.8.6


### PR DESCRIPTION
Our previous approach to dependencies was creating a high barrier to entry for new contributors (and new Pythonistas/Djangonauts) since it required them to have a production environment installed locally just to install the requirements files.

This change moves production-specific dependencies to a separate module, simplifies local setup, and opens the possiblity of having development specific dependencies in the future.

closes #37