### PR TITLE
Adds a setting to prevent sending emails in a local environment.

### DIFF
--- a/python-in-edu/mysite/settings.py
+++ b/python-in-edu/mysite/settings.py
@@ -235,3 +235,5 @@ if 'EMAIL_HOST' in os.environ:  # running on heroku, probably
     DEFAULT_FROM_EMAIL = os.environ.get('DEFAULT_FROM_EMAIL')
 else:
     DEFAULT_FROM_EMAIL = "example@example.com"
+
+SEND_MAIL = 'PY_IN_EDU_DONT_SEND_MAIL' not in os.environ

--- a/python-in-edu/resources/models.py
+++ b/python-in-edu/resources/models.py
@@ -6,7 +6,7 @@ from django.urls import reverse
 
 from multiselectfield import MultiSelectField
 
-from mysite.settings import DEFAULT_FROM_EMAIL
+from mysite.settings import DEFAULT_FROM_EMAIL, SEND_MAIL
 from . import choices
 
 
@@ -83,7 +83,7 @@ class Resource(models.Model):
 
 def resource_updated(sender, instance, created, **kwargs):
 
-    if created:
+    if created and SEND_MAIL:
         staff_emails = [user.email for user in User.objects.all() if user.is_staff and user.email]
         subj = "A new resource has been proposed on Python In Education"
         url = "http://education.python.org" + reverse('admin:resources_resource_change', args=[instance.pk])


### PR DESCRIPTION
Not connected to an issue, but the environment variable `PY_IN_EDU_DONT_SEND_MAIL` being set in your environment to any value will turn of the email send on resource creation. This allows local development without an SMTP server and defaults to keeping it on to make sure non-local dev continues to work as expected.