### PR TITLE
Fixed static files path and changed registration form #56 and 59

### DIFF
--- a/python-in-edu/mysite/settings.py
+++ b/python-in-edu/mysite/settings.py
@@ -47,6 +47,7 @@ INSTALLED_APPS = [
     'resources',
     'django.contrib.admin',
     'multiselectfield',
+    'crispy_forms',
 ]
 
 MIDDLEWARE = [

--- a/python-in-edu/mysite/settings.py
+++ b/python-in-edu/mysite/settings.py
@@ -140,12 +140,12 @@ USE_TZ = True
 
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/1.9/howto/static-files/
-STATIC_ROOT = os.path.join(BASE_DIR, 'static_build')
+STATIC_ROOT = os.path.join(BASE_DIR, 'static_source')
 STATIC_URL = '/static/'
 
 # Extra places for collectstatic to find static files.
 STATICFILES_DIRS = (
-    os.path.join(BASE_DIR, 'static_source'),
+    os.path.join(BASE_DIR, 'static_build'),
 )
 
 

--- a/python-in-edu/mysite/settings.py
+++ b/python-in-edu/mysite/settings.py
@@ -49,7 +49,7 @@ INSTALLED_APPS = [
     'multiselectfield',
     'crispy_forms',
 ]
-
+CRISPY_TEMPLATE_PACK = 'bootstrap4'
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',

--- a/python-in-edu/resources/templates/django_registration/registration_form.html
+++ b/python-in-edu/resources/templates/django_registration/registration_form.html
@@ -6,7 +6,7 @@
 <div class="col-2"></div>
 <div class="col-8">
 
-    <h5>Register</h5>
+    <h3>Register</h3>
 
     <form method="post">
         {% csrf_token %}
@@ -14,15 +14,13 @@
         {% for field in form %}
         <p>
             {% if field.errors %}
-            <ul>
-                <h6 style="color:red;">
-                    {% for error in field.errors %}
-                    <li>{{ error }}</li>
-                    {% endfor %}
-                </h6>
-            </ul>
+            <h6 style="color:red;">
+                {% for error in field.errors %}
+                {{ error }}
+                {% endfor %}
+            </h6>
             {% endif %}
-            {{ field.label_tag }} {{ field }}
+            {{ field|as_crispy_field }}
         </p>
         {% endfor %}
 

--- a/python-in-edu/resources/templates/django_registration/registration_form.html
+++ b/python-in-edu/resources/templates/django_registration/registration_form.html
@@ -1,7 +1,7 @@
 {% extends "resources/base.html" %}
+{% load crispy_forms_tags %}
 
 {% block content %}
-
 
 <div class="col-2"></div>
 <div class="col-8">
@@ -11,14 +11,24 @@
     <form method="post">
         {% csrf_token %}
 
-        {{ form.errors }}
-
-        {{ form }}
+        {% for field in form %}
+        <p>
+            {% if field.errors %}
+            <ul>
+                <h6 style="color:red;">
+                    {% for error in field.errors %}
+                    <li>{{ error }}</li>
+                    {% endfor %}
+                </h6>
+            </ul>
+            {% endif %}
+            {{ field.label_tag }} {{ field }}
+        </p>
+        {% endfor %}
 
         <button type="submit" class="btn btn-info" id="submit_registration">Submit</button>
     </form>
 
 </div>
-
 
 {% endblock content %}


### PR DESCRIPTION
1. Initially, static files weren't getting loaded as STATIC_ROOT and STATICFILES_DIRS were interchanged. These are corrected now.
2. Crispy forms were added to the registration form.
3. Registration form is changed to show errors in the fields in red color.