### PR TITLE
add margin-top to resource detail container for proper looking

### DIFF
--- a/python-in-edu/resources/templates/resources/resource_detail.html
+++ b/python-in-edu/resources/templates/resources/resource_detail.html
@@ -5,7 +5,7 @@
 
 {% block content %}
 
-<div class="container">
+<div class="container mt-4">
 
     <div class="row">
 


### PR DESCRIPTION
### The Resource Page Content Should be margined horizontally 
so the resource details container in ``` python-in-edu/resources/templates/resources/resource_detail.html ```:

```
{% block content %}

<div class="container"> 

.
.
.

</div>

{% endblock content %}
```

### doesn't be sticked to the navbar like this:

<img width="1124" height="521" alt="image" src="https://github.com/user-attachments/assets/b59ce936-4e1d-455a-ba5e-214ccc26c448" /><br>

### finally, Thanks for this awesome project
 